### PR TITLE
Minor tweak to README and binmat check

### DIFF
--- a/R/make-bin-mat.R
+++ b/R/make-bin-mat.R
@@ -108,7 +108,7 @@ binmat <- function(patients=NULL, maf = NULL, mut.type = "SOMATIC",SNP.only = FA
   }
 
   # if keep_onco KB is populated, then oncokb should be set to TRUE
-  if (!is.null(keep_onco) & (is.null(oncokb) | oncokb == FALSE)){
+  if (!missing(keep_onco) & (missing(oncokb) | oncokb == FALSE)){
     warning("keep_onco is specified, but oncoKB annotation is not being
             performed. If you wish to keep records on the basis of oncoKB
             annotation, set the oncokb parameter to TRUE.")

--- a/R/make-bin-mat.R
+++ b/R/make-bin-mat.R
@@ -107,6 +107,13 @@ binmat <- function(patients=NULL, maf = NULL, mut.type = "SOMATIC",SNP.only = FA
     }
   }
 
+  # if keep_onco KB is populated, then oncokb should be set to TRUE
+  if (!is.null(keep_onco) & (is.null(oncokb) | oncokb == FALSE)){
+    warning("keep_onco is specified, but oncoKB annotation is not being
+            performed. If you wish to keep records on the basis of oncoKB
+            annotation, set the oncokb parameter to TRUE.")
+  }
+
   # make patients/samples list #
   if(is.null(patients)){
     patients <- c()

--- a/README.Rmd
+++ b/README.Rmd
@@ -75,7 +75,7 @@ CBIOPORTAL_TOKEN = 'YOUR_TOKEN'
 You can test your connection using:
 
 ```{r,eval = F}
-get_cbioportal_token()
+cbioportalr::get_cbioportal_token()
 ```
 
 


### PR DESCRIPTION
Hi gnomeR team! 

I wanted to submit two very minor tweaks in this PR, feel free to take or leave however you prefer.

The first was a small addition to the README to specify the namespace for the `get_cbioportal_token` function. 

The second tweak is to catch a bug I had in my own code that I thought others could encounter as well. I had the input parameter 'oncokb' misspelled  (:facepalm:) but didn't notice that oncoKB annotation wasn't being performed since I also had `keep_onco = c("Oncogenic", "Likely Oncogenic")` and the code ran without warning or errors. I added a check in binmat that makes sure `oncokb` is specified to be TRUE when `keep_onco` isn't missing. 

Thanks for considering these additions! 