### PR TITLE
Fix bug in pivot_cna_longer and add option for CNA high level only

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -158,7 +158,7 @@
 
 #' IMPACT Alias Tables
 #'
-#' Table of aliases for IMPACT panel genes
+#' Table of aliases for IMPACT panel genes used for gene name resolution functionality.
 #'
 #' @format A data frame with 1658 rows
 #' \describe{

--- a/R/pivot-cna.R
+++ b/R/pivot-cna.R
@@ -140,9 +140,15 @@ pivot_cna_longer <- function(wide_cna, clean_sample_ids = TRUE) {
   switch(length(missing_cols) > 0,
          cli::cli_abort("Missing columns: {.field {missing_cols}}"))
 
+  no_hugo <- select(cna, -"hugo_symbol")
+
+  switch(any(purrr::map_lgl(no_hugo, ~!is.numeric(.x))),
+         cli::cli_abort(c("All CNA columns must be numeric. Do you need to convert to numeric? Eg. ",
+         "{.code mutate(data, across(.cols = c(everything(), -Hugo_Symbol), ~ as.numeric(.x)))} ?"))
+  )
 
   # Remove Patients with no CNA ------------------------------------------------
-  no_hugo <- select(cna, -"hugo_symbol")
+
 
   patient_sums <- apply(no_hugo, 2, function(x) sum(abs(x), na.rm = TRUE))
 

--- a/R/resolve-gene-aliases.R
+++ b/R/resolve-gene-aliases.R
@@ -3,6 +3,13 @@
 
 #' Recode Hugo Symbol Column
 #'
+#'
+#' Searches the Hugo Symbol column in a genomic dataframe to look for
+#' any genes that have common gene name aliases,
+#' and replaces those aliases with the accepted (most recent) gene name.
+#' Function uses `gnomeR::impact_alias_table` by default as reference for
+#' which aliases to replace and supports IMPACT panel alias replacement only at this time.
+#'
 #' @param genomic_df a gene_binary object
 #' @param ... Other things passed
 #'

--- a/R/sanitize-data.R
+++ b/R/sanitize-data.R
@@ -8,7 +8,7 @@
 #' @export
 #'
 #' @examples
-#' sanitize_mutation_input(mutation = gnomeR::mutations)
+#' sanitize_mutation_input(mutation = gnomeR::mutations, include_silent = FALSE)
 #'
 sanitize_mutation_input <- function(mutation, include_silent, ...)  {
 

--- a/R/sanitize-data.R
+++ b/R/sanitize-data.R
@@ -1,6 +1,7 @@
 #' Checks MAF input to ensure column names are correct and renamed genes are corrected
 #'
 #' @param mutation Raw maf dataframe containing alteration data
+#' @param include_silent Silent mutations will be removed if FALSE (default). Variant classification column is needed.
 #' @param ... other arguments passed from create_gene_binary() (recode.aliases).
 #' @return a corrected maf file or an error if problems with maf
 #' @keywords internal
@@ -9,7 +10,7 @@
 #' @examples
 #' sanitize_mutation_input(mutation = gnomeR::mutations)
 #'
-sanitize_mutation_input <- function(mutation, ...)  {
+sanitize_mutation_input <- function(mutation, include_silent, ...)  {
 
   arguments <- list(...)
 
@@ -29,6 +30,14 @@ sanitize_mutation_input <- function(mutation, ...)  {
   mutation <- mutation %>%
     mutate(sample_id = as.character(.data$sample_id),
            hugo_symbol = as.character(.data$hugo_symbol))
+
+  # if include_silent FALSE, check for variant classification column
+  if(!include_silent & !("variant_classification" %in% names(mutation))) {
+    cli::cli_abort("No {.var variant_classification} column found therefore
+                   silent mutations can't be removed. Please set {.code include_silent = TRUE}
+                   or add a {.var variant_classification} column.")
+  }
+
 
   if("variant_classification" %in% column_names) {
   # Check for Fusions-  Old API used to return fusions --------------

--- a/R/sanitize-data.R
+++ b/R/sanitize-data.R
@@ -122,7 +122,7 @@ sanitize_fusion_input <- function(fusion, ...)  {
   which_missing <- required_cols[which(!(required_cols %in% column_names))]
 
   if(length(which_missing) > 0) {
-    cli::cli_abort("The following required columns are missing in your mutations data: {.field {which_missing}}")
+    cli::cli_abort("The following required columns are missing in your fusions data: {.field {which_missing}}")
   }
 
   # Make sure they are character
@@ -162,7 +162,7 @@ sanitize_cna_input <- function(cna, ...)  {
   which_missing <- required_cols[which(!(required_cols %in% column_names))]
 
   if(length(which_missing) > 0) {
-    cli::cli_abort("The following required columns are missing in your mutations data: {.field {which_missing}}.
+    cli::cli_abort("The following required columns are missing in your CNA data: {.field {which_missing}}.
                    Is your data in wide format? If so, it must be long format. See {.code gnomeR::pivot_cna_long()} to reformat")
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -62,7 +62,7 @@ substrRight <- function(x, n) {
 #' Internal function to recode numeric CNA alteration values to factor values
 #'
 #' @param alteration_vector a vector of CNA alterations coded with any of the
-#' following levels: neutral, deletion, amplification, homozygous deletion,
+#' following levels: neutral, deletion, amplification, gain, loss, homozygous deletion,
 #' hemizygous deletion, loh, gain, high level amplification, 0, -1, -1.5, -2, 1, 2.
 #'
 #' @return a recoded CNA data set with factor alteration values. See details for code dictionary
@@ -94,18 +94,18 @@ recode_cna <- function(alteration_vector){
   levels_in_data <- tolower(names(table(alteration_vector)))
 
   # source: https://docs.cbioportal.org/file-formats/#data-file-1
-  # python annotator ref: https://github.com/oncokb/oncokb-annotator/blob/47e4a158ee843ead75445982532eb149db7f3106/AnnotatorCore.py#L158
+  # python annotator ref with codes: https://github.com/oncokb/oncokb-annotator/blob/47e4a158ee843ead75445982532eb149db7f3106/AnnotatorCore.py#L158
    allowed_cna_levels <- tibble::tribble(
                ~detailed_coding, ~numeric_coding,   ~final_coding,
-                      "neutral",             "0",       "neutral",
-          "homozygous deletion",            "-2",      "deletion",
-                          "loh",          "-1.5",      "deletion",
-          "hemizygous deletion",            "-1",      "deletion",
-                         "gain",             "1", "amplification",
-      "high level amplification",            "2", "amplification")
+                      "neutral",          "0",        "neutral",
+                    "deep loss",          "-2",      "deletion",
+                    "deep loss",          "-1.5",    "deletion",
+          "hemizygous deletion",          "-1",       "loss",
+                         "gain",          "1",        "gain",
+     "high level amplification",          "2",   "amplification")
 
 
-  # throw error if any values not in allowed list
+
   all_allowed <- unlist(allowed_cna_levels)
   not_allowed <- levels_in_data[!levels_in_data %in% all_allowed]
 
@@ -121,7 +121,9 @@ recode_cna <- function(alteration_vector){
   names(recode_values) <- c(allowed_cna_levels$final_coding, allowed_cna_levels$final_coding)
 
   recoded_alterations <- suppressWarnings(
-    forcats::fct_recode(alteration_vector, !!!recode_values))
+    forcats::fct_recode(alteration_vector, !!!recode_values)
+    )
+
 
     return(recoded_alterations)
   }
@@ -154,8 +156,8 @@ recode_cna <- function(alteration_vector){
     filter(.data$sample_id %in% samples)
 
   data_out <- switch(type,
-                     del = filter(data_out, .data$alteration %in% c("deletion","homozygous deletion","hemizygous deletion")),
-                     amp = filter(data_out, .data$alteration %in% c("amplification","high level amplification")),
+                     del = filter(data_out, .data$alteration %in% c("deletion")),
+                     amp = filter(data_out, .data$alteration %in% c("amplification")),
                      mut = data_out,
                      fus = data_out)
 

--- a/man/create_gene_binary.Rd
+++ b/man/create_gene_binary.Rd
@@ -13,6 +13,7 @@ create_gene_binary(
   include_silent = FALSE,
   fusion = NULL,
   cna = NULL,
+  high_level_cna_only = FALSE,
   specify_panel = "no",
   recode_aliases = TRUE
 )
@@ -38,6 +39,9 @@ Default is NULL.}
 
 \item{cna}{A data frame of copy number alterations. If inputed the outcome will be added to the matrix with columns ending in ".del" and ".amp".
 Default is NULL.}
+
+\item{high_level_cna_only}{If TRUE, only deep deletions (-2, -1.5) or high level amplifications (2) will be counted as events
+in the binary matrix. Gains (1) and losses (1) will be ignored. Default is \code{FALSE} where all CNA events are counted.}
 
 \item{specify_panel}{a character vector of length 1 with panel id (see gnomeR::gene_panels for available panels), "impact", or "no", or a
 data frame of \code{sample_id}-\code{panel_id} pairs specifying panels for which to insert NAs indicating that gene was not tested.

--- a/man/dot-cna_gene_binary.Rd
+++ b/man/dot-cna_gene_binary.Rd
@@ -4,7 +4,13 @@
 \alias{.cna_gene_binary}
 \title{Make Binary Matrix From CNA data frame}
 \usage{
-.cna_gene_binary(cna, samples, specify_panel, recode_aliases)
+.cna_gene_binary(
+  cna,
+  samples,
+  specify_panel,
+  recode_aliases,
+  high_level_cna_only
+)
 }
 \arguments{
 \item{cna}{A data frame of copy number alterations. If inputed the outcome will be added to the matrix with columns ending in ".del" and ".amp".
@@ -26,6 +32,9 @@ annotated with NAs according to that specific panel.}
 
 \item{recode_aliases}{boolean specifying if automated gene name alias matching should be done. Default is TRUE. When TRUE
 the function will check for genes that may have more than 1 name in your data using the aliases im gnomeR::impact_gene_info alias column}
+
+\item{high_level_cna_only}{If TRUE, only deep deletions (-2, -1.5) or high level amplifications (2) will be counted as events
+in the binary matrix. Gains (1) and losses (1) will be ignored. Default is \code{FALSE} where all CNA events are counted.}
 }
 \value{
 a data frame

--- a/man/impact_alias_table.Rd
+++ b/man/impact_alias_table.Rd
@@ -17,6 +17,6 @@ A data frame with 1658 rows
 impact_alias_table
 }
 \description{
-Table of aliases for IMPACT panel genes
+Table of aliases for IMPACT panel genes used for gene name resolution functionality.
 }
 \keyword{datasets}

--- a/man/pivot_cna_longer.Rd
+++ b/man/pivot_cna_longer.Rd
@@ -17,7 +17,10 @@ no modification will be made to returned \code{sample_ids} field}
 A long data frame of CNA events
 }
 \description{
-Reformat Wide CNA Data to Long
+Takes a numeric vector of CNA data in wide format where each column is a sample
+and each row is a hugo symbol. Function will return a long format CNA data set
+of just events (neutral/diploid instances are filtered out) and will recode events from
+numeric to descriptive (-2/-1/-1.5 is deletion, 2/1 is amplification).
 }
 \examples{
 cna <- pivot_cna_longer(wide_cna = gnomeR::cna_wide)

--- a/man/recode_alias.Rd
+++ b/man/recode_alias.Rd
@@ -15,7 +15,11 @@ recode_alias(genomic_df, ...)
 A dataframe with a recoded Hugo Symbol columns
 }
 \description{
-Recode Hugo Symbol Column
+Searches the Hugo Symbol column in a genomic dataframe to look for
+any genes that have common gene name aliases,
+and replaces those aliases with the accepted (most recent) gene name.
+Function uses \code{gnomeR::impact_alias_table} by default as reference for
+which aliases to replace and supports IMPACT panel alias replacement only at this time.
 }
 \examples{
 mut <- rename_columns(gnomeR::mutations)

--- a/man/recode_cna.Rd
+++ b/man/recode_cna.Rd
@@ -8,7 +8,7 @@ recode_cna(alteration_vector)
 }
 \arguments{
 \item{alteration_vector}{a vector of CNA alterations coded with any of the
-following levels: neutral, deletion, amplification, homozygous deletion,
+following levels: neutral, deletion, amplification, gain, loss, homozygous deletion,
 hemizygous deletion, loh, gain, high level amplification, 0, -1, -1.5, -2, 1, 2.}
 }
 \value{

--- a/man/sanitize_mutation_input.Rd
+++ b/man/sanitize_mutation_input.Rd
@@ -4,10 +4,12 @@
 \alias{sanitize_mutation_input}
 \title{Checks MAF input to ensure column names are correct and renamed genes are corrected}
 \usage{
-sanitize_mutation_input(mutation, ...)
+sanitize_mutation_input(mutation, include_silent, ...)
 }
 \arguments{
 \item{mutation}{Raw maf dataframe containing alteration data}
+
+\item{include_silent}{Silent mutations will be removed if FALSE (default). Variant classification column is needed.}
 
 \item{...}{other arguments passed from create_gene_binary() (recode.aliases).}
 }
@@ -18,7 +20,7 @@ a corrected maf file or an error if problems with maf
 Checks MAF input to ensure column names are correct and renamed genes are corrected
 }
 \examples{
-sanitize_mutation_input(mutation = gnomeR::mutations)
+sanitize_mutation_input(mutation = gnomeR::mutations, include_silent = FALSE)
 
 }
 \keyword{internal}

--- a/tests/testthat/test-binary-matrix.R
+++ b/tests/testthat/test-binary-matrix.R
@@ -1,8 +1,8 @@
 
-# Test Binary Matrix Arguments -----------------------------------------------------------
+# Test Binary Matrix  -----------------------------------------------------------
 
 
-# test samples argument ----
+# Test samples argument ----
 # what happens when you pass a vector? What about if you don't specify it (don't pass anything)?
 # what happens when you pass impact samples (-IM5/IM6/IM7 etc)?  non impact samples? A mix?
 
@@ -42,7 +42,7 @@ test_that("samples selected with no fusions ",  {
 
   samples <- setdiff(gnomeR::mutations$sampleId, gnomeR::sv$sampleId)[1:5]
 
-  # with no fusions in select sample---------
+  # with no fusions in select sample
   gene_binary_no_fusions <-  create_gene_binary(samples=samples,
                                             mutation = gnomeR::mutations,
                                             fusion = gnomeR::sv)
@@ -56,7 +56,7 @@ test_that("samples selected with no CNA ", {
 
   samples <- setdiff(gnomeR::mutations$sampleId, gnomeR::cna$sampleId)[1:5]
 
-  # with no fusions in select sample---------
+  # with no fusions in select sample
   gene_binary_no_cna<-  create_gene_binary(samples=samples,
                                                 mutation = gnomeR::mutations,
                                                 cna = gnomeR::cna)
@@ -88,11 +88,11 @@ test_that("samples selected with no mutations ", {
 
 # NON UNIQUE SAMPLES in samples ARGUMENT?
 
-# test with and without mut/fusion/cna args passed ----
+# Test data type arguments ------------------------------------------------
+
+# test with and without mut/fusion/cna args passed
+
 # Functions should work with any one of the three passed
-# Does it return results as expected?
-# Trying with and without passing samples arg as well- does it return what you'd expect?
-# what if mut is passed but doesn't have any rows? no columns? no rows or cols?
 test_that("test inputting mut/fusion/cna args can leads to a data.frame output", {
 
   #Can we obtaine correct result format when either mut/fusion/cna inputted
@@ -120,7 +120,8 @@ test_that("test inputting mut/fusion/cna args can leads to a data.frame output",
 
 })
 
-# test mut_type argument ----
+
+# Test mut_type argument --------------------------------------------------
 
 test_that("test incorrectly specified arg", {
 
@@ -177,83 +178,73 @@ test_that("test inclusion of NAs in mut_type ", {
 
 
 
-# Test high_level_cna_only  ----------------------------------------------------
+# Test high_level_cna_only argument --------------------------------------------
 
 test_that("test deletions with -1 and -2 events", {
 
   test_cna <- tibble::tribble(
     ~hugo_symbol, ~sample_id, ~alteration,
     "TP53",        "samp1",     1,
-    "ALK3",        "samp2",     -1,
+    "BMPR1A",      "samp2",     -1,
+    "CDKN2A",      "samp2",     -1.5,
     "FGFR3",       "samp3",      2,
     "FGFR3",       "samp4",      0,
-    "TP53",        "samp2",      1
+    "TP53",        "samp2",      -2
   )
 
   test_mut <- tibble::tribble(
-    ~hugo_symbol, ~sample_id,  ~variant_type,
-    "TP53",        "samp1",     "SNP",
-    "ALK3",        "samp2",     "SNP",
-    "FGFR3",       "samp3",     "SNP",
-    "FGFR3",       "samp4",     "SNP",
-    "TP53",        "samp2",     "SNP"
+    ~hugo_symbol, ~sample_id,  ~variant_type,  ~mutation_status,   ~variant_classification,
+    "TP53",        "samp1",     "SNP",          "Somatic",          "Silent",
+    "BMPR1A",      "samp2",     "SNP",          "Somatic",           NA,
+    "FGFR3",       "samp3",     "SNP",          "Somatic",           NA,
+    "FGFR3",       "samp4",     "SNP",          "Somatic",           NA,
+    "TP53",        "samp2",     "SNP",          "Somatic",           NA
   )
 
   test_fus <- tibble::tribble(
     ~site_1_hugo_symbol, ~site_2_hugo_symbol, ~sample_id,
-    "TP53",               "ALK3",             "samp1",
-    "ALK3",               "APC",              "samp2",
+    "TP53",               "BMPR1A",           "samp1",
+    "BMPR1A",              "APC",             "samp2",
     "FGFR3",              "TP53",             "samp3",
     "FGFR3",              "KMT2D",            "samp4",
     "TP53",               NA,                 "samp2"
   )
 
-  proc <- create_gene_binary(
+  samples <- c(test_mut$sample_id,
+               test_cna$sample_id,
+               test_fus$sample_id) %>% unique()
+
+  proc_all_cna <- create_gene_binary(
+    samples = samples,
     mutation = test_mut,
     cna = test_cna,
-    fusion = test_fus)
+    fusion = test_fus,
+    include_silent = TRUE,
+    high_level_cna_only = FALSE)
+
+  proc_hl_cna <- create_gene_binary(
+    samples = samples,
+    mutation = test_mut,
+    cna = test_cna,
+    fusion = test_fus,
+    include_silent = TRUE,
+    high_level_cna_only = TRUE)
 
 
+  ll_genes <- test_cna %>% filter(alteration == 1 |
+                        alteration == -1) %>%
+    pull(hugo_symbol)
 
+  diff_gene <- str_remove(
+    setdiff(names(proc_all_cna), names(proc_hl_cna)), ".Amp|.Del")
 
-
-  test_data <- test_data %>%
-    mutate(alteration = recode_cna(alteration))
-
-  expect_no_error()
-  x <- test_data %>%
-    filter(alteration == "deletion") %>%
-    select(sample_id, hugo_symbol) %>% distinct()
-
-  # check results
-  expect_equal(nrow(proc), length(unique(x$sample_id)))
-  expect_equal(ncol(proc)-1, length(unique(x$hugo_symbol)))
-
-
-  res_tab <- paste0(x$hugo_symbol, ".Del") %>% table() %>% c()
-  res_func <- purrr::map_dbl(proc[, -1], ~sum(.x))
-  res_tab <- res_tab[names(res_func)]
-
-  expect_equal(res_tab, res_func)
+  expect_equal(sort(ll_genes), sort(diff_gene))
 
 })
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-# test include_silent arg----
+# Test include_silent argument --------------------------------------------
 
 test_that("test include_silent default when no variant class col", {
 
@@ -284,8 +275,14 @@ test_that("test include_silent default when no variant class col", {
     "TP53",               NA,                 "samp2"
   )
 
+
+  samples <- c(test_mut$sample_id,
+               test_cna$sample_id,
+               test_fus$sample_id) %>% unique()
+
   expect_error(
     proc <- create_gene_binary(
+      samples = samples,
       mutation = test_mut,
       cna = test_cna,
       fusion = test_fus))
@@ -293,6 +290,7 @@ test_that("test include_silent default when no variant class col", {
   expect_no_error(
     proc <- create_gene_binary(
       mutation = test_mut,
+      samples = samples,
       cna = test_cna,
       fusion = test_fus,
       include_silent = TRUE,
@@ -315,7 +313,7 @@ test_that("test include_silent silent are removed when variant class col", {
     ~hugo_symbol, ~sample_id,  ~variant_type,  ~mutation_status,   ~variant_classification,
     "TP53",        "samp1",     "SNP",          "Somatic",          "Silent",
     "BMPR1A",      "samp2",     "SNP",          "Somatic",           NA,
-    "FGFR3",       "samp3",     "SNP",          "Somatic",           NA,
+    "FGFR3",       "samp3",     "SNP",          "Somatic",           "Other",
     "FGFR3",       "samp4",     "SNP",          "Somatic",           NA,
     "TP53",        "samp2",     "SNP",          "Somatic",           NA
   )
@@ -329,13 +327,21 @@ test_that("test include_silent silent are removed when variant class col", {
     "TP53",               NA,                 "samp2"
   )
 
+
+  samples <- c(test_mut$sample_id,
+               test_cna$sample_id,
+               test_fus$sample_id) %>% unique()
+
+
   proc_remove_silent1 <- create_gene_binary(
+      samples = samples,
       mutation = test_mut,
       cna = test_cna,
       fusion = test_fus)
 
 
   proc_remove_silent2 <- create_gene_binary(
+    samples = samples,
     mutation = test_mut,
     cna = test_cna,
     include_silent = FALSE,
@@ -345,6 +351,7 @@ test_that("test include_silent silent are removed when variant class col", {
 
   proc_keep_silent <-
     create_gene_binary(
+      samples = samples,
       mutation = test_mut,
       cna = test_cna,
       include_silent = TRUE,
@@ -352,10 +359,15 @@ test_that("test include_silent silent are removed when variant class col", {
 
   expect_lt(sum(proc_remove_silent1$TP53), sum(proc_keep_silent$TP53))
 
+  # make sure FGFGR "Other" type was still included in results
+  expect_equal(sum(proc_remove_silent1$FGFR3), sum(proc_keep_silent$FGFR3))
+
 })
 
 
-# test snp_only arg----
+
+# Test snp_only argument --------------------------------------------------
+
 # add general tests
 # What happpens  when Variant Type is NA? - Maybe need to add warning to tell user about NAs
 # test_that("test the snp_only arg", {
@@ -400,34 +412,7 @@ test_that("test include_silent silent are removed when variant class col", {
 # })
 
 
-# test include_silent arg----
 
-
-
-
-# add general tests
-# What happens  when Variant_Classification is NA for some samples in passed data? - Maybe need to add warning to tell user about NAs
-# test_that("test include_silent arg", {
-#
-#   #general tests: input T or F (default is F)
-#   expect_error( create_gene_binary(mutation=gnomeR::mutations, include_silent = T), NA)
-#
-#   expect_warning( create_gene_binary(mutation=gnomeR::mutations,
-#                                      include_silent =  T, recode_aliases = FALSE), NA)
-#
-#
-#   #What if NA for variantType?
-#   # note: without Variant Type, the create_gene_binary() still run without error
-#   #       snp_only=F will provide full list results and snp_only=T will provide 0 col result
-#
-#   mut_vc_na<- gnomeR::mutations %>%
-#     dplyr::mutate(variantType=NA)
-#
-#   expect_equal( create_gene_binary(mutation = mut_vc_na, include_silent = F) %>% ncol(), 0 )
-#
-#   expect_true( create_gene_binary(mutation = mut_vc_na, include_silent = T) %>% ncol() > 0 )
-#
-# })
-
+# Other Misc Tests --------------------------------------------------------
 
 

--- a/tests/testthat/test-pivot-cna.R
+++ b/tests/testthat/test-pivot-cna.R
@@ -321,3 +321,53 @@ test_that("pivot CNA- test with NA data", {
                pivot_cna_longer(cna_wide_na, clean_sample_ids = FALSE))
 
 })
+
+
+test_that("pivot CNA- test with character columns", {
+
+  cna_wide_na <- tibble::tribble(
+    ~Hugo_Symbol, ~P.0070637.T01.IM7, ~P.0042589.T01.IM6, ~P.0026544.T01.IM6, ~P.0032011.T01.IM6,
+    "CRKL",                 0L,                 NA,                 0L,                 -2L,
+    "SCG5",                 0L,                 0L,                 0L,                 0L,
+    "STK11",                 1L,                 0L,                 0L,                 0L,
+    "MEN1",                 0L,                 0L,                 0L,                 0L,
+    "B2M",                 0L,                 2L,                 0L,                 0L,
+    "TAP2",                 NA,                 0L,                 0L,                 0L,
+    "PMAIP1",                 0L,                 0L,                 0L,                 0L,
+    "H3-3A",                 0L,                 0L,                 0L,                 0L,
+    "H3-3B",                 0L,                 0L,                 NA,                 0L,
+    "CDC73",                 0L,                 0L,                 0L,                 0L,
+    "PIK3CA",                 0L,                 0L,                 0L,                 -1L
+  )
+
+  cna_wide_chr <- cna_wide_na %>%
+    mutate(across(.cols = c(everything(), -Hugo_Symbol), ~ as.character(.x)))
+
+  expect_error(pivot_cna_longer(cna_wide_chr, clean_sample_ids = FALSE))
+
+})
+
+
+test_that("pivot CNA- test with some character, some numeric columns", {
+
+  cna_wide_na <- tibble::tribble(
+    ~Hugo_Symbol, ~P.0070637.T01.IM7, ~P.0042589.T01.IM6, ~P.0026544.T01.IM6, ~P.0032011.T01.IM6,
+    "CRKL",                 0L,                 NA,                 0L,                 -2L,
+    "SCG5",                 0L,                 0L,                 0L,                 0L,
+    "STK11",                 1L,                 0L,                 0L,                 0L,
+    "MEN1",                 0L,                 0L,                 0L,                 0L,
+    "B2M",                 0L,                 2L,                 0L,                 0L,
+    "TAP2",                 NA,                 0L,                 0L,                 0L,
+    "PMAIP1",                 0L,                 0L,                 0L,                 0L,
+    "H3-3A",                 0L,                 0L,                 0L,                 0L,
+    "H3-3B",                 0L,                 0L,                 NA,                 0L,
+    "CDC73",                 0L,                 0L,                 0L,                 0L,
+    "PIK3CA",                 0L,                 0L,                 0L,                 -1L
+  )
+
+  cna_wide_chr <- cna_wide_na %>%
+    mutate(across(.cols = c(`P.0070637.T01.IM7`), ~ as.character(.x)))
+
+  expect_error(pivot_cna_longer(cna_wide_chr, clean_sample_ids = FALSE))
+
+})

--- a/tests/testthat/test-pivot-cna.R
+++ b/tests/testthat/test-pivot-cna.R
@@ -216,3 +216,108 @@ test_that("pivot CNA- test clean_sample_ids = FALSE", {
   expect_no_message(long_cna_1 <- pivot_cna_longer(cna_wide, clean_sample_ids = FALSE))
   expect_true(any(str_detect(long_cna_1$sample_id, fixed(".")))) })
 
+test_that("pivot CNA- test patients with no events are not returned", {
+
+  cna_wide <- tibble::tribble(
+    ~Hugo_Symbol, ~P.0070637.T01.IM7, ~P.0042589.T01.IM6, ~P.0026544.T01.IM6, ~P.0032011.T01.IM6,
+    "CRKL",                 0L,                 0L,                 0L,                 -2L,
+    "SCG5",                 0L,                 0L,                 0L,                 0L,
+    "STK11",                 1L,                 0L,                 0L,                 0L,
+    "MEN1",                 0L,                 0L,                 0L,                 0L,
+    "B2M",                 0L,                 2L,                 0L,                 0L,
+    "TAP2",                 0L,                 0L,                 0L,                 0L,
+    "PMAIP1",                 0L,                 0L,                 0L,                 0L,
+    "H3-3A",                 0L,                 0L,                 0L,                 0L,
+    "H3-3B",                 0L,                 0L,                 0L,                 0L,
+    "CDC73",                 0L,                 0L,                 0L,                 0L,
+    "PIK3CA",                 0L,                 0L,                 0L,                 -1L
+  )
+  no_hugo <- select(cna_wide, -Hugo_Symbol)
+  patient_sums <- apply(no_hugo, 2, function(x) sum(abs(x), na.rm = TRUE))
+
+  patient_with_cna <- patient_sums[patient_sums > 0] %>%
+    names()
+
+  cna_long <- pivot_cna_longer(cna_wide, clean_sample_ids = FALSE)
+
+  expect_equal(sort(unique(cna_long$sample_id)), sort(patient_with_cna))
+
+  })
+
+
+test_that("pivot CNA- test number of CNA returned", {
+
+  cna_wide <- tibble::tribble(
+    ~Hugo_Symbol, ~P.0070637.T01.IM7, ~P.0042589.T01.IM6, ~P.0026544.T01.IM6, ~P.0032011.T01.IM6,
+    "CRKL",                 0L,                 0L,                 0L,                 -2L,
+    "SCG5",                 0L,                 0L,                 0L,                 0L,
+    "STK11",                 1L,                 0L,                 0L,                 NA,
+    "MEN1",                 0L,                 0L,                 0L,                 0L,
+    "B2M",                 0L,                 2L,                 0L,                 0L,
+    "TAP2",                 0L,                 0L,                 0L,                 0L,
+    "PMAIP1",                 0L,                 0L,                 0L,                 0L,
+    "H3-3A",                 0L,                 0L,                 -1.5,                 0L,
+    "H3-3B",                 0L,                 0L,                 0L,                 0L,
+    "CDC73",                 NA,                 0L,                 0L,                 0L,
+    "PIK3CA",                 0L,                 0L,                 0L,                 -1L
+  )
+
+  no_hugo <- dplyr::select(cna_wide, -Hugo_Symbol)
+  gene_table <- no_hugo %>%
+    tidyr::pivot_longer(everything()) %>%
+    unique() %>%
+    dplyr::filter(value != 0)
+
+  check <- case_when(
+    gene_table$value %in% c(-2, -1.5) ~ "deletion",
+    gene_table$value %in% c( -1) ~ "loss",
+    gene_table$value %in% c(2) ~ "amplification",
+    gene_table$value %in% c(1) ~ "gain")
+
+
+
+  cna_long <- pivot_cna_longer(cna_wide, clean_sample_ids = FALSE)
+
+
+  expect_equal(as.character(cna_long$alteration), check)
+
+})
+
+
+
+test_that("pivot CNA- test with NA data", {
+
+  cna_wide_zero <- tibble::tribble(
+    ~Hugo_Symbol, ~P.0070637.T01.IM7, ~P.0042589.T01.IM6, ~P.0026544.T01.IM6, ~P.0032011.T01.IM6,
+    "CRKL",                 0L,                 0L,                 0L,                 -2L,
+    "SCG5",                 0L,                 0L,                 0L,                 0L,
+    "STK11",                 1L,                 0L,                 0L,                 0L,
+    "MEN1",                 0L,                 0L,                 0L,                 0L,
+    "B2M",                 0L,                 2L,                 0L,                 0L,
+    "TAP2",                 0L,                 0L,                 0L,                 0L,
+    "PMAIP1",                 0L,                 0L,                 0L,                 0L,
+    "H3-3A",                 0L,                 0L,                 0L,                 0L,
+    "H3-3B",                 0L,                 0L,                 0L,                 0L,
+    "CDC73",                 0L,                 0L,                 0L,                 0L,
+    "PIK3CA",                 0L,                 0L,                 0L,                 -1L
+  )
+
+  cna_wide_na <- tibble::tribble(
+    ~Hugo_Symbol, ~P.0070637.T01.IM7, ~P.0042589.T01.IM6, ~P.0026544.T01.IM6, ~P.0032011.T01.IM6,
+    "CRKL",                 0L,                 NA,                 0L,                 -2L,
+    "SCG5",                 0L,                 0L,                 0L,                 0L,
+    "STK11",                 1L,                 0L,                 0L,                 0L,
+    "MEN1",                 0L,                 0L,                 0L,                 0L,
+    "B2M",                 0L,                 2L,                 0L,                 0L,
+    "TAP2",                 NA,                 0L,                 0L,                 0L,
+    "PMAIP1",                 0L,                 0L,                 0L,                 0L,
+    "H3-3A",                 0L,                 0L,                 0L,                 0L,
+    "H3-3B",                 0L,                 0L,                 NA,                 0L,
+    "CDC73",                 0L,                 0L,                 0L,                 0L,
+    "PIK3CA",                 0L,                 0L,                 0L,                 -1L
+  )
+
+  expect_equal(pivot_cna_longer(cna_wide_zero, clean_sample_ids = FALSE),
+               pivot_cna_longer(cna_wide_na, clean_sample_ids = FALSE))
+
+})

--- a/tests/testthat/test-process-binary.R
+++ b/tests/testthat/test-process-binary.R
@@ -1,6 +1,9 @@
 
 
 
+# Test mutations ----------------------------------------------------------
+
+
 test_that("check results for mutations", {
 
   samp <- unique(gnomeR::mutations$sampleId)
@@ -24,6 +27,9 @@ test_that("check results for mutations", {
   expect_equal(res_tab, res_func)
 
 })
+
+
+# Test Fusions ------------------------------------------------------------
 
 
 
@@ -53,6 +59,8 @@ test_that("check results for fusions", {
 })
 
 
+# Test CNA ----------------------------------------------------------------
+
 test_that("check results for deletions", {
 
   samp <- unique(gnomeR::cna$sampleId)
@@ -78,6 +86,8 @@ test_that("check results for deletions", {
   expect_equal(res_tab, res_func)
 
 })
+
+
 
 test_that("check results for amplifications", {
 
@@ -105,6 +115,9 @@ test_that("check results for amplifications", {
 
 })
 
+
+
+# Misc --------------------------------------------------------------------
 
 
 test_that("sample passed that has events", {

--- a/tests/testthat/test-sanitize.R
+++ b/tests/testthat/test-sanitize.R
@@ -1,18 +1,21 @@
 
 test_that("both sanitize functions run with no errors", {
-  expect_error(sanitize_mutation_input(gnomeR::mutations), NA)
+  expect_error(sanitize_mutation_input(gnomeR::mutations, include_silent = FALSE), NA)
+  expect_error(sanitize_mutation_input(gnomeR::mutations, include_silent = TRUE), NA)
   expect_error(sanitize_fusion_input(gnomeR::sv), NA)
 })
 
 
 test_that("both sanitize functions run without warnings",{
-  expect_warning(sanitize_mutation_input(gnomeR::mutations), NA)
+  expect_warning(sanitize_mutation_input(gnomeR::mutations, include_silent = FALSE), NA)
+  expect_warning(sanitize_mutation_input(gnomeR::mutations, include_silent = TRUE), NA)
   expect_warning(sanitize_fusion_input(gnomeR::sv), NA)
 })
 
 test_that("test to see what happens if pass sanitize a vector", {
   expect_error(sanitize_mutation_input(gnomeR::mutations %>%
-                                           select(-Hugo_Symbol)))
+                                           select(-Hugo_Symbol),
+                                       include_silent = FALSE))
   expect_error(sanitize_fusion_input(gnomeR::sv %>%
                                          select(-Hugo_Symbol)))
 })


### PR DESCRIPTION
**What changes are proposed in this pull request?**
 This PR fixes a bug in CNA processing in `pivot_cna_longer()`.

Additionally, I changed the way CNA is coded internally and added an argument `high_level_cna_only` to allow users to only annotate high level dels/amps. By default it will count any type of alt as an event. 

Another change is that `pivot_cna_longer()` now only returns events and all `neutral` events are filtered out. 



--------------------------------------------------------------------------------

  Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch. Ensure the pull request branch and your local version match and both have the latest updates from the main branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `withr::with_envvar(new = c("NOT_CRAN" = "true"), covr::report())`. Begin in a fresh R session without any packages loaded.
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
 - [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cbioportalR (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Run `codemetar::write_codemeta()`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR
