### PR TITLE
Testing sanitize data functions

### DIFF
--- a/R/sanitize-data.R
+++ b/R/sanitize-data.R
@@ -78,7 +78,7 @@ sanitize_mutation_input <- function(mutation, include_silent, ...)  {
 
         cli::cli_warn("Column {.field variant_type} is missing from your data. We inferred variant types using {.field reference_allele} and {.field tumor_seq_allele2} columns")
       } else {
-        TRUE ~ cli::cli_abort("Column {.field variant_type} is missing from your data and {.field reference_allele} and {.field tumor_seq_allele2}
+        cli::cli_abort("Column {.field variant_type} is missing from your data and {.field reference_allele} and {.field tumor_seq_allele2}
                               columns were not available from which to infer variant type.
                               To proceed, add a column specifying {.field variant_type} (e.g. {.code mutate(<your-mutation-df>, variant_type = 'SNP')}")
       }

--- a/tests/testthat/test-sanitize.R
+++ b/tests/testthat/test-sanitize.R
@@ -41,3 +41,23 @@ test_that("both sanitize functions run with no errors", {
   expect_error(sanitize_mutation_input(mutations), "The following*")
 
 })
+
+# --------------------------------------------------------------
+## added by cw on 4/26/23
+# sanitize_fusion_input(fusion)
+# colnames(fusion)
+
+# test fusion in variant classification
+
+test_that("test fusion in variant classification", {
+  mutation = gnomeR::mutations
+  mutation <- rename_columns(mutation)
+  column_names <- colnames(mutation)
+  mutation$variant_classification[mutation$variant_classification == "In_Frame_Del"] <- "fusion"
+
+  # fusions_in_maf <- mutation %>%
+  #   filter(.data$variant_classification %in% c("Fusion", "fusion"))
+  expect_error(sanitize_mutation_input(mutation, include_silent = F), "It looks like you have fusions in your mutation data frame.*")
+})
+
+

--- a/tests/testthat/test-sanitize.R
+++ b/tests/testthat/test-sanitize.R
@@ -75,5 +75,37 @@ test_that("test fusion in variant classification", {
   expect_no_error(sanitize_mutation_input(mutation, include_silent = F))
 })
 
+# variant type
+
+test_that("test variant type", {
+  mutation = gnomeR::mutations
+  mutation <- rename_columns(mutation)
+  column_names <- colnames(mutation)
+  mutation = mutation %>% select(-c(variant_type, reference_allele))
+
+  expect_error(sanitize_mutation_input(mutation, include_silent = F))
+})
+
+test_that("test variant type inference", {
+  mutation = gnomeR::mutations
+  mutation <- rename_columns(mutation)
+  column_names <- colnames(mutation)
+  mutation = mutation %>% select(-c(variant_type))
+  mutation$tumor_seq_allele2 = mutation$reference_allele
+
+  expect_warning(sanitize_mutation_input(mutation, include_silent = F))
+})
+
+
+test_that("test variant type inference error", {
+  mutation = gnomeR::mutations
+  mutation <- rename_columns(mutation)
+  column_names <- colnames(mutation)
+  mutation$tumor_seq_allele2 = mutation$reference_allele
+  mutation = mutation %>% select(-c(variant_type, reference_allele))
+
+  expect_error(sanitize_mutation_input(mutation, include_silent = F))
+})
+
 
 

--- a/tests/testthat/test-sanitize.R
+++ b/tests/testthat/test-sanitize.R
@@ -55,9 +55,25 @@ test_that("test fusion in variant classification", {
   column_names <- colnames(mutation)
   mutation$variant_classification[mutation$variant_classification == "In_Frame_Del"] <- "fusion"
 
-  # fusions_in_maf <- mutation %>%
-  #   filter(.data$variant_classification %in% c("Fusion", "fusion"))
   expect_error(sanitize_mutation_input(mutation, include_silent = F), "It looks like you have fusions in your mutation data frame.*")
 })
+
+# check suggested columns
+# mutation status column
+
+test_that("test fusion in variant classification", {
+  mutation = gnomeR::mutations
+  mutation <- rename_columns(mutation)
+  column_names <- colnames(mutation)
+  mutation = mutation %>% select(-mutation_status)
+
+  expect_warning(sanitize_mutation_input(mutation, include_silent = F), "A mutation_status column*")
+
+  mutation = mutation %>%
+    mutate(mutation_status = "SOMATIC")
+
+  expect_no_error(sanitize_mutation_input(mutation, include_silent = F))
+})
+
 
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Unit test for fusions in dataframe, check for mutation status and variant type columns. Minor change to sanitize_mutation_input function to check if columns are available to infer variant type when column doesn't exist

**If there is an GitHub issue associated with this pull request, please provide link.**
https://github.com/MSKCC-Epi-Bio/gnomeR/issues/144

--------------------------------------------------------------------------------

  Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch. Ensure the pull request branch and your local version match and both have the latest updates from the main branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `withr::with_envvar(new = c("NOT_CRAN" = "true"), covr::report())`. Begin in a fresh R session without any packages loaded.
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
 - [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cbioportalR (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Run `codemetar::write_codemeta()`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR
