### PR TITLE
Mutation type matrix for ggoncoprint retained after `create_gene_binary()`

### DIFF
--- a/R/create-gene-binary.R
+++ b/R/create-gene-binary.R
@@ -259,7 +259,7 @@ create_gene_binary <- function(samples = NULL,
       all_alias_warnings <- c(all_alias_warnings, q_cna_warn)
 
       if (save_var_class) {
-        cna_vc_alias <- rename_cna %>%
+        cna_vc_alias <- cna_var_class %>%
           recode_alias(.,
                        alias_table = recode_aliases,
                        supress_warnings = TRUE)%>%

--- a/R/utils.R
+++ b/R/utils.R
@@ -242,4 +242,3 @@ recode_cna <- function(alteration_vector){
   }
 }
 
-

--- a/tests/testthat/test-binary-matrix.R
+++ b/tests/testthat/test-binary-matrix.R
@@ -489,8 +489,25 @@ test_that("test include_silent silent are removed when variant class col", {
 #
 # })
 
+# Test save_var_class argument --------------------------------
+
+test_that("check attribute 'var_class' based on save_var_class", {
+
+  test_true <- create_gene_binary(mutation = gnomeR::mutations,
+                                    save_var_class = TRUE)
+
+  test_false <- create_gene_binary(mutation = gnomeR::mutations)
+
+  expect_true(!is.null(attr(test_true, "var_class")))
+  expect_true(is.null(attr(test_false, "var_class")))
+})
+
+test_that("missing a column that's needed for save_var_class", {
+  expect_error(create_gene_binary(mutation = gnomeR::mutations %>%
+                                  select(-mutationType),
+                     save_var_class = TRUE))
+})
 
 
 # Other Misc Tests --------------------------------------------------------
-
 


### PR DESCRIPTION
**What changes are proposed in this pull request?**
Added var_class attribute option to `create_gene_binary()` which retains a long form of the mutation/fusion/cna files with variant_classification values. Haven't made official tests but works with ggoncoprint so far, so I'll add an issue to add tests.

**If there is an GitHub issue associated with this pull request, please provide link.**
#263 

--------------------------------------------------------------------------------

  Reviewer Checklist (if item does not apply, mark is as complete)

- [ ] PR branch has pulled the most recent updates from main branch. Ensure the pull request branch and your local version match and both have the latest updates from the main branch.
- [ ] If a new function was added, function included in `_pkgdown.yml`
- [ ] If a bug was fixed, a unit test was added for the bug check
- [ ] Run `pkgdown::build_site()`. Check the R console for errors, and review the rendered website.
- [ ] Code coverage is suitable for any new functions/features. Review coverage with `withr::with_envvar(new = c("NOT_CRAN" = "true"), covr::report())`. Begin in a fresh R session without any packages loaded.
- [ ] R CMD Check runs without errors, warnings, and notes
- [ ] `usethis::use_spell_check()` runs with no spelling errors in documentation

When the branch is ready to be merged into master:
 - [ ] Update `NEWS.md` with the changes from this pull request under the heading "`# cbioportalR (development version)`". If there is an issue associated with the pull request, reference it in parentheses at the end update (see `NEWS.md` for examples).
- [ ] Run `codemetar::write_codemeta()`
- [ ] Run `usethis::use_spell_check()` again
- [ ] Approve Pull Request
- [ ] Merge the PR
